### PR TITLE
Handle long URIs

### DIFF
--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -71,6 +71,7 @@ def recent_incidents_for_services(services, time_window):
             return recent_incidents
         raise
 
+
 def print_all_incidents(
     silent,
     time_window_days,

--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -56,17 +56,12 @@ def recent_incidents_for_services(services, time_window):
     except urllib.error.HTTPError as e:
         if e.reason == 'URI Too Long':
             mid_point = int(len(service_ids)/2)
-            recent_incidents = list(pagerduty_service.incidents.list(
-                service_ids=service_ids[:mid_point],
-                since=datetime.now() - time_window,
-            ))
-            recent_incidents.extend(
-                list(
-                    pagerduty_service.incidents.list(
-                        service_ids=service_ids[mid_point:],
-                        since=datetime.now() - time_window,
-                    )
-                )
+            return recent_incidents_for_services(
+               service_ids=service_ids[:mid_point],
+               time_window=time_window
+            ) + recent_incidents_for_services(
+               service_ids=service_ids[mid_point:],
+               time_window=time_window
             )
             return recent_incidents
         raise

--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -63,7 +63,6 @@ def recent_incidents_for_services(services, time_window):
                service_ids=service_ids[mid_point:],
                time_window=time_window
             )
-            return recent_incidents
         raise
 
 


### PR DESCRIPTION
If an escalation policy has over 155 services, this script will create a URL that is too long for urllib3 to handle.

This PR handles that case by splitting up that call into 2 chunks.