### PR TITLE
Upgrade python-dateutil for py3.9 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pygerduty==0.38.3
-python-dateutil==2.4.2
+python-dateutil==2.8.2
 prettytable==2.5.0


### PR DESCRIPTION
Was getting this error in the dateutil lib

```
Traceback (most recent call last):
  File "/Users/cwoo/src/opsreview/pull_alerts.py", line 230, in <module>
    print_all_incidents(
  File "/Users/cwoo/src/opsreview/pull_alerts.py", line 82, in print_all_incidents
    formatted_incidents = get_formatted_incidents(recent_incidents)
  File "/Users/cwoo/src/opsreview/pull_alerts.py", line 127, in get_formatted_incidents
    formatted_incident.created_on = dateutil.parser.parse(incident.created_at).astimezone(LOCAL_TZ)
  File "/Users/cwoo/src/opsreview/venv/lib/python3.10/site-packages/dateutil/parser.py", line 1008, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/Users/cwoo/src/opsreview/venv/lib/python3.10/site-packages/dateutil/parser.py", line 410, in parse
    if (isinstance(tzinfos, collections.Callable) or
AttributeError: module 'collections' has no attribute 'Callable'
```

Upgrading the lib resolves it