### PR TITLE
Upgrade python-dateutil version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pygerduty==0.38.3
-python-dateutil==2.4.2
+python-dateutil==2.8.2


### PR DESCRIPTION
Getting this error in dateutil.parser.parse


`  File "/Users/rajagubba/src/opsreview/pull_alerts.py", line 224, in <module>
    print_all_incidents(
  File "/Users/rajagubba/src/opsreview/pull_alerts.py", line 74, in print_all_incidents
    formatted_incidents = get_formatted_incidents(recent_incidents)
  File "/Users/rajagubba/src/opsreview/pull_alerts.py", line 122, in get_formatted_incidents
    print(dateutil.parser.parse(incident.created_at))
  File "/Users/rajagubba/src/opsreview/venv3/lib/python3.10/site-packages/dateutil/parser.py", line 1008, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/Users/rajagubba/src/opsreview/venv3/lib/python3.10/site-packages/dateutil/parser.py", line 410, in parse
    if (isinstance(tzinfos, collections.Callable) or
AttributeError: module 'collections' has no attribute 'Callable'`
