### PR TITLE
Fix missing service_id param

### DIFF
--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -55,13 +55,13 @@ def recent_incidents_for_services(services, time_window):
 
     except urllib.error.HTTPError as e:
         if e.reason == 'URI Too Long':
-            mid_point = int(len(service_ids)/2)
+            mid_point = int(len(services)/2)
             return recent_incidents_for_services(
-               service_ids=service_ids[:mid_point],
-               time_window=time_window
+               services[:mid_point],
+               time_window,
             ) + recent_incidents_for_services(
-               service_ids=service_ids[mid_point:],
-               time_window=time_window
+               services[mid_point:],
+               time_window,
             )
         raise
 


### PR DESCRIPTION
Bandaid fix to get pull_alerts.py working again; somehow https://github.com/lyft/opsreview/pull/31 specified keyword args incorrectly.

```
Traceback (most recent call last):
  File "$PATH/opsreview/pull_alerts.py", line 233, in <module>
    print_all_incidents(
  File "$PATH/opsreview/pull_alerts.py", line 84, in print_all_incidents
    recent_incidents = recent_incidents_for_services(services, timedelta(days=time_window_days))
TypeError: recent_incidents_for_services() missing 1 required positional argument: 'service_ids'
```

Have tested this and it works.