### PR TITLE
Fix bug with different number of pages in different timezones

### DIFF
--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -6,7 +6,6 @@ import logging
 import urllib
 from collections import Counter, OrderedDict, defaultdict, namedtuple
 from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
 
 from dateutil import tz
 import dateutil.parser
@@ -51,7 +50,7 @@ def recent_incidents_for_services(services, time_window):
     try:
         recent_incidents = list(pagerduty_service.incidents.list(
             service_ids=service_ids,
-            since=datetime.now(tz=ZoneInfo("America/Los_Angeles")) - time_window
+            since=datetime.now(tz=LOCAL_TZ) - time_window
         ))
         return recent_incidents
 

--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -6,7 +6,6 @@ import logging
 import urllib
 from collections import Counter, OrderedDict, defaultdict, namedtuple
 from datetime import datetime, timedelta
-
 from dateutil import tz
 import dateutil.parser
 

--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -51,7 +51,7 @@ def recent_incidents_for_services(services, time_window):
     try:
         recent_incidents = list(pagerduty_service.incidents.list(
             service_ids=service_ids,
-            since=datetime.now(tz=ZoneInfo("America/Los_Angeles")) - time_window
+            since=datetime.now(tz=ZoneInfo("Europe/Minsk")) - time_window
         ))
         return recent_incidents
 
@@ -89,7 +89,6 @@ def print_all_incidents(
         group_by_service
     )
     print_stats(all_incidents, include_stats)
-    # all_incidents = [i for i in all_incidents if 5 <= i.created_on.hour <= 15]
     if include_incidents_as_blockquote:
         print("""# Raw incident log
 ```

--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -6,6 +6,8 @@ import logging
 import urllib
 from collections import Counter, OrderedDict, defaultdict, namedtuple
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
 from dateutil import tz
 import dateutil.parser
 
@@ -49,7 +51,7 @@ def recent_incidents_for_services(services, time_window):
     try:
         recent_incidents = list(pagerduty_service.incidents.list(
             service_ids=service_ids,
-            since=datetime.now() - time_window
+            since=datetime.now(tz=ZoneInfo("Europe/Minsk")) - time_window
         ))
         return recent_incidents
 
@@ -87,6 +89,7 @@ def print_all_incidents(
         group_by_service
     )
     print_stats(all_incidents, include_stats)
+    # all_incidents = [i for i in all_incidents if 5 <= i.created_on.hour <= 15]
     if include_incidents_as_blockquote:
         print("""# Raw incident log
 ```

--- a/pull_alerts.py
+++ b/pull_alerts.py
@@ -51,7 +51,7 @@ def recent_incidents_for_services(services, time_window):
     try:
         recent_incidents = list(pagerduty_service.incidents.list(
             service_ids=service_ids,
-            since=datetime.now(tz=ZoneInfo("Europe/Minsk")) - time_window
+            since=datetime.now(tz=ZoneInfo("America/Los_Angeles")) - time_window
         ))
         return recent_incidents
 


### PR DESCRIPTION
Fix bug with missing timezone, due to which `pull_alerts.py` print different number of pages in different timezones.

The problem is that the `datetime.now()` object takes the local time, but doesn't add information about the timezone, as a result, pagerduty doesn't know from what time to collect pages and therefore uses some default timezone, because of this, `pull_alerts.py` script will print different number of pages in Europe and USA.

To fix this, we need to add information about the timezone, and **it doesn’t matter** which timezone [will be there](https://github.com/lyft/opsreview/pull/36/files#diff-0052311b4eedfd69118e059e6a7e4339d465ae632361809321aa302084769d7cR52), for any time zone, absolute time will remain the same.

All the screenshots below were taken ~at the same time (5:30 AM, Pacific).
&#10;
&#10;
&#10;
**Without fix**:
Local time - Europe/Minsk: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Local time - America/Los Angeles
<img alt="local - minsk, pacific 5 30" src="https://github.com/lyft/opsreview/assets/45463018/088d3afc-997b-4b90-b8de-3b7dcba02b20" width="398" height="186" >  <img alt="local - los angeles, pacific 5 30 png" src="https://github.com/lyft/opsreview/assets/45463018/898b57fd-56cc-4574-818e-57fe7b29748b" width="398" height="186">
As you can see, the number of pages is different (18 vs 22), even though the script run at the same time.
&#10;
&#10;
&#10;
**With fix** (test with `datetime.now(tz=ZoneInfo("America/Los_Angeles"))` in code):
Local time - Europe/Minsk: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Local time - America/Los Angeles
<img alt="local - minsk, pacific 5 30" src="https://github.com/lyft/opsreview/assets/45463018/cc925a91-28d2-4000-bb06-268c93554589" width="398" height="186" >  <img alt="local - los angeles, pacific 5 30 png" src="https://github.com/lyft/opsreview/assets/45463018/7cc7e999-faaa-49fa-b143-95617576945d" width="398" height="186">

**With fix** (test with `datetime.now(tz=ZoneInfo("Europe/Minsk"))` in code):
Local time - Europe/Minsk: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Local time - America/Los Angeles
<img alt="local - minsk, pacific 5 30" src="https://github.com/lyft/opsreview/assets/45463018/354e21ea-78aa-4855-a0a8-80c8b8d57b56" width="398" height="186" >  <img alt="local - los angeles, pacific 5 30 png" src="https://github.com/lyft/opsreview/assets/45463018/3b15a1db-e960-4937-8115-6cce651d7fd4" width="398" height="186">

As you can see, the number of pages is always the same (22).